### PR TITLE
Detect new device added only use /dev/ttyUSB* devices

### DIFF
--- a/cgminer/files/cgminer-monitor
+++ b/cgminer/files/cgminer-monitor
@@ -29,18 +29,13 @@ if [ "$A" == "$B" ]; then
 fi
 
 # If there new device added, restart cgminer
-B=`cgminer-api devs | grep "^   \[ASC\]" | wc -l`
-if [ "$?" != "0" ]; then
-    killall -s 9 cgminer
-    sleep 1
-    /etc/init.d/cgminer restart
-    exit 0;
-fi
-
-A=`find /dev/ -name "ttyUSB*" | wc -l`
+B=`find /dev/ -name "ttyUSB*" | wc -l`
+A=`cat /tmp/usbnr.log`
+echo -n "$B" > /tmp/usbnr.log
 if [ "$A" != "$B" ]; then
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
     exit 0;
 fi
+


### PR DESCRIPTION
Xiangfu: I found some usb device are not working avalon machine,so use more simple method instead.
