### PR TITLE
Add libncurses for all

### DIFF
--- a/cgminer/Makefile
+++ b/cgminer/Makefile
@@ -36,11 +36,7 @@ define Package/cgminer
 	CATEGORY:=Utilities
 	TITLE:=cgminer
 	URL:=https://github.com/ckolivas/cgminer
-ifeq ($(CONFIG_TARGET_brcm2708_RaspberryPi),y)
 	DEPENDS:=+libcurl +libpthread +jansson +udev +libncurses
-else
-	DEPENDS:=+libcurl +libpthread +jansson +udev
-endif
 endef
 
 define Package/cgminer/description


### PR DESCRIPTION
tl-wr1043nd-v2 and tl-wr703n-v1 requires libncurses too.
[Error Information]
Package cgminer is missing dependencies for the following libraries:
libncurses.so.5
