### PR TITLE
Bug fix for Makefile: extraneous \'endif\'

### DIFF
--- a/cgminer/Makefile
+++ b/cgminer/Makefile
@@ -71,8 +71,6 @@ define Build/Prepare
 	(cd $(PKG_BUILD_DIR); patch -Np1 < 0001-avalon2.patch;)
 endef
 
-endif
-
 define Build/Compile
 	$(call Build/Compile/Default)
 	(cd $(PKG_BUILD_DIR) && \


### PR DESCRIPTION
The bad Makefile can't build.
