### PR TITLE
Update cgminer monitor script to log why cgminer is restarted

### DIFF
--- a/cgminer/files/cgminer-avalon8-monitor
+++ b/cgminer/files/cgminer-avalon8-monitor
@@ -1,29 +1,53 @@
 #!/bin/sh
 # This file is for cron job
 
+LOG_FILE="/tmp/cgminer-monitor.log"
+PID_FILE="/tmp/cgminer.pid"
+MAX_SIZE=8388608
+
+# Check log file
+[ ! -e $LOG_FILE ] && echo "Timestamp: `wget -q -O - www.worldtimeserver.com/time-zones/hkt | grep 'Server Time with' | awk '{print $6}'`; `date +%Y%m%d_%H%M%S`" >> $LOG_FILE
+
+# Generate pid file
+[ ! -e $PID_FILE ] && pidof cgminer > $PID_FILE && echo "[`date +%Y%m%d_%H%M%S`] Generating pid file: `pidof cgminer`" >> $LOG_FILE
+
+# Check size of log file
+[ "`ls -l /tmp/cgminer-monitor.log | awk '{print $5}'`" -ge "$MAX_SIZE" ] && sed -i '1d;2d;3d;4d;5d;6d;7d;8d' $LOG_FILE && echo "Timestamp: `wget -q -O - www.worldtimeserver.com/time-zones/hkt | grep 'Server Time with' | awk '{print $6}'`; `date +%Y%m%d_%H%M%S`" >> $LOG_FILE
+
+# Check pid
+[ "`pidof cgminer`" != "`cat $PID_FILE`" ] && echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
+
 # Make sure there is only one cgminer running
 C=`pidof cgminer | wc -w`
 if [ "$C" != "1" ]; then
+    echo "[`date +%Y%m%d_%H%M%S`] Kill multiple cgminers" >> $LOG_FILE
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
+    echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
     exit 0;
 fi
 
-# Make sure the devices staill active
+# Make sure the devices still active
 B=`cgminer-api devs | grep "^   \[Last Share Time\]"`
 if [ "$?" != "0" ]; then
+    echo "[`date +%Y%m%d_%H%M%S`] Devices not active" >> $LOG_FILE
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
+    echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
     exit 0;
 fi
 
 A=`cat /tmp/cm.log`
 echo -n "$B" > /tmp/cm.log
 if [ "$A" == "$B" ]; then
+    echo "[`date +%Y%m%d_%H%M%S`] No changes of monitor log" >> $LOG_FILE
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
+    echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
     exit 0;
 fi
+
+[ -x /tmp/ping_heartbeat.sh ] && /tmp/ping_heartbeat.sh &

--- a/cgminer/files/cgminer-avalon8-monitor
+++ b/cgminer/files/cgminer-avalon8-monitor
@@ -50,4 +50,5 @@ if [ "$A" == "$B" ]; then
     exit 0;
 fi
 
+# Check whether exist network check script, if yes, trigger it. The network check script can be injected into RPi by ams server and only stays in memory(RAM), it will run less than 3 minutes every time.
 [ -x /tmp/ping_heartbeat.sh ] && /tmp/ping_heartbeat.sh &

--- a/cgminer/files/cgminer-avalon9-monitor
+++ b/cgminer/files/cgminer-avalon9-monitor
@@ -1,29 +1,53 @@
 #!/bin/sh
 # This file is for cron job
 
+LOG_FILE="/tmp/cgminer-monitor.log"
+PID_FILE="/tmp/cgminer.pid"
+MAX_SIZE=8388608
+
+# Check log file
+[ ! -e $LOG_FILE ] && echo "Timestamp: `wget -q -O - www.worldtimeserver.com/time-zones/hkt | grep 'Server Time with' | awk '{print $6}'`; `date +%Y%m%d_%H%M%S`" >> $LOG_FILE
+
+# Generate pid file
+[ ! -e $PID_FILE ] && pidof cgminer > $PID_FILE && echo "[`date +%Y%m%d_%H%M%S`] Generating pid file: `pidof cgminer`" >> $LOG_FILE
+
+# Check size of log file
+[ "`ls -l /tmp/cgminer-monitor.log | awk '{print $5}'`" -ge "$MAX_SIZE" ] && sed -i '1d;2d;3d;4d;5d;6d;7d;8d' $LOG_FILE && echo "Timestamp: `wget -q -O - www.worldtimeserver.com/time-zones/hkt | grep 'Server Time with' | awk '{print $6}'`; `date +%Y%m%d_%H%M%S`" >> $LOG_FILE
+
+# Check pid
+[ "`pidof cgminer`" != "`cat $PID_FILE`" ] && echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
+
 # Make sure there is only one cgminer running
 C=`pidof cgminer | wc -w`
 if [ "$C" != "1" ]; then
+    echo "[`date +%Y%m%d_%H%M%S`] Kill multiple cgminers" >> $LOG_FILE
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
+    echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
     exit 0;
 fi
 
-# Make sure the devices staill active
+# Make sure the devices still active
 B=`cgminer-api devs | grep "^   \[Last Share Time\]"`
 if [ "$?" != "0" ]; then
+    echo "[`date +%Y%m%d_%H%M%S`] Devices not active" >> $LOG_FILE
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
+    echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
     exit 0;
 fi
 
 A=`cat /tmp/cm.log`
 echo -n "$B" > /tmp/cm.log
 if [ "$A" == "$B" ]; then
+    echo "[`date +%Y%m%d_%H%M%S`] No changes of monitor log" >> $LOG_FILE
     killall -s 9 cgminer
     sleep 1
     /etc/init.d/cgminer restart
+    echo "[`date +%Y%m%d_%H%M%S`] Pid of cgminer has been changed from `cat $PID_FILE` to `pidof cgminer`" >> $LOG_FILE && pidof cgminer > $PID_FILE
     exit 0;
 fi
+
+[ -x /tmp/ping_heartbeat.sh ] && /tmp/ping_heartbeat.sh &

--- a/cgminer/files/cgminer-avalon9-monitor
+++ b/cgminer/files/cgminer-avalon9-monitor
@@ -50,4 +50,5 @@ if [ "$A" == "$B" ]; then
     exit 0;
 fi
 
+# Check whether exist network check script, if yes, trigger it. The network check script can be injected into RPi by ams server and only stays in memory(RAM), it will run less than 3 minutes every time.
 [ -x /tmp/ping_heartbeat.sh ] && /tmp/ping_heartbeat.sh &


### PR DESCRIPTION
This change will log reasons of cgminer process restarts.
At the same time, if a network checking script exist in /tmp/ folder, it will be triggerred to check whether RPi has good connection with public internet and local ams server. If not, these ping results will be uploaded to ams server so that we know RPi's network status.